### PR TITLE
Remove Custom Migrations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
           "branch": null,
-          "revision": "10d33362a47fab03a067e78fb0791341d9c634fa",
-          "version": "3.9.3"
+          "revision": "18f2436bf7a6bc2224372c0885db2e0159af1649",
+          "version": "3.9.2"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/vapor/fluent.git",
         "state": {
           "branch": null,
-          "revision": "783819d8838d15e1a05b459aa0fd1bde1e37ac26",
-          "version": "3.2.1"
+          "revision": "b915c321c6f9e83743ee5efa35a30895e1b02e51",
+          "version": "3.2.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/vapor/multipart.git",
         "state": {
           "branch": null,
-          "revision": "f063180d0b84832accd33194e06ed3c41f8609ac",
-          "version": "3.1.1"
+          "revision": "f919a01c4d10a281d6236a21b0b1d1759a72b8eb",
+          "version": "3.0.4"
         }
       },
       {

--- a/Sources/App/Models/Extensions.swift
+++ b/Sources/App/Models/Extensions.swift
@@ -15,53 +15,7 @@ extension Player: Migration {}
 extension Player: Content {}
 extension Player: Model {}
 
-extension Player: PostgreSQLMigration {
-    public static func prepare(on connection: PostgreSQLConnection) -> EventLoopFuture<Void> {
-        return PostgreSQLDatabase.create(Player.self, on: connection) { builder in
-            builder.field(for: \.id, isIdentifier: true)
-            builder.field(for: \.Bats)
-            builder.field(for: \.FullName)
-            builder.field(for: \.Postion)
-            builder.field(for: \.TeamID)
-            builder.field(for: \.TeamName)
-        }
-    }
-    
-    public static func revert(on connection: PostgreSQLConnection) -> EventLoopFuture<Void> {
-        return PostgreSQLDatabase.delete(Player.self, on: connection)
-    }
-}
-
-
 extension Player.CareerHittingStats: PostgreSQLModel {}
 extension Player.CareerHittingStats: Migration {}
 extension Player.CareerHittingStats: Content {}
 extension Player.CareerHittingStats: Model {}
-
-extension Player.CareerHittingStats: PostgreSQLMigration {
-    public static func prepare(on connection: PostgreSQLConnection) -> EventLoopFuture<Void> {
-        return PostgreSQLDatabase.create(Player.CareerHittingStats.self, on: connection) { builder in
-            builder.field(for: \.id, isIdentifier: true)
-            builder.field(for: \.Homeruns)
-            builder.field(for: \.AtBats)
-            builder.field(for: \.BaseOnBalls)
-            builder.field(for: \.BattingAverage)
-            builder.field(for: \.BattingAverageOnBallsInPlay)
-            builder.field(for: \.Games)
-            builder.field(for: \.GroundedIntoDoublePlay)
-            builder.field(for: \.HitByPitch)
-            builder.field(for: \.Hits)
-            builder.field(for: \.NumberOfPitches)
-            builder.field(for: \.OnBasePercentage)
-            builder.field(for: \.OnBasePlusSlugging)
-            builder.field(for: \.Runs)
-            builder.field(for: \.RunsBattedIn)
-            builder.field(for: \.SluggingAverage)
-            builder.field(for: \.TotalBases)
-        }
-    }
-    
-    public static func revert(on connection: PostgreSQLConnection) -> EventLoopFuture<Void> {
-        return PostgreSQLDatabase.delete(Player.CareerHittingStats.self, on: connection)
-    }
-}


### PR DESCRIPTION
- Migrations for Player & CareerHittingStats Aren't needed
- They can be infered by the type itself